### PR TITLE
feat: implementa CRUD completo da entidade Brand

### DIFF
--- a/brand/forms.py
+++ b/brand/forms.py
@@ -1,0 +1,16 @@
+from django.forms import ModelForm
+from brand.models import Brand
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Submit
+
+class BrandForm(ModelForm):
+    class Meta:
+        model = Brand
+        fields = '__all__'
+        
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.form_method = 'post'
+        self.helper.form_class = 'brandForm'
+        self.helper.add_input(Submit('submit', 'Salvar'))

--- a/brand/urls.py
+++ b/brand/urls.py
@@ -1,7 +1,9 @@
 from django.urls import path
-from django.shortcuts import render
-from brand.views import BrandListView
+from brand.views import BrandListView, BrandCreateView, BrandUpdateView, BrandDeleteView
 
 urlpatterns = [
-    path('brand/', BrandListView.as_view(), name="brand_list_view" ),
+    path('brand/', BrandListView.as_view(), name="brand_list_view"),
+    path('brand/create/', BrandCreateView.as_view(), name="brand_create_view"),
+    path('brand/update/<int:pk>/', BrandUpdateView.as_view(), name="brand_update_view"),
+    path('brand/delete/<int:pk>/', BrandDeleteView.as_view(), name="brand_delete_view"),
 ]

--- a/brand/views.py
+++ b/brand/views.py
@@ -1,5 +1,10 @@
-from django.views.generic import ListView
+from django.views.generic import ListView, CreateView, UpdateView, DeleteView
 from brand.models import Brand
+from brand.forms import BrandForm
+from django.urls import reverse_lazy  # Importe reverse_lazy
+from django.http import JsonResponse
+from django.template.loader import render_to_string
+from django.shortcuts import render
 
 
 class BrandListView(ListView):
@@ -7,11 +12,66 @@ class BrandListView(ListView):
     template_name = 'list_brands.html'
     context_object_name = 'brands'
 
-    def get_queryset(self):  # trás os dados do banco de dados de forma personalizada, por exemplo, quero apenas produtos de tal marca, é isso que esse método faz
-        # O super respeita as regras da view, por isso a gente pega os objetos assim, ao invés de Brand.objects.all(), assim a gente já travalha em cima dos dados
+    def get_queryset(self):
         queryset = super().get_queryset()
-        name = self.request.GET.get('name')  
+        name = self.request.GET.get('name')
 
         if name:
             queryset = queryset.filter(name__icontains=name)
         return queryset.order_by('id')
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        brand_forms = {
+            brand.pk: BrandForm(
+                instance=brand, prefix=f'{brand.pk}'
+            )
+            for brand in context['brands']
+            if brand.pk  # <- só cria se tiver pk
+        }
+        context['brand_forms'] = brand_forms
+        return context
+
+
+class BrandCreateView(CreateView):
+    model = Brand
+    template_name = 'create_brands.html'
+    form_class = BrandForm
+
+    def get_success_url(self):
+        return reverse_lazy('brand_list_view')
+
+
+class BrandUpdateView(UpdateView):
+    model = Brand
+    template_name = 'update_modal.html'
+    form_class = BrandForm
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs['prefix'] = str(self.object.pk)
+        return kwargs
+
+    def get_success_url(self):
+        return reverse_lazy('brand_list_view')
+
+    def form_valid(self, form):
+        form.save()
+        return JsonResponse({'success': 'Marca atualizada!'})
+
+    def form_invalid(self, form):
+        print("Erros do form:", form.errors)
+        return render(self.request, self.template_name, {'form': form, 'brand': self.object}, status=400)
+
+
+class BrandDeleteView(DeleteView):
+    model = Brand
+    template_name = 'delete_confirm.html'
+
+    def get_success_url(self):
+        return reverse_lazy('brand_list_view')
+
+    def post(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        self.object.delete()
+        return JsonResponse({'success': True})


### PR DESCRIPTION
#Este PR entrega a implementação completa do CRUD para a entidade Brand, incluindo:

-Views baseadas em função para criar, listar, editar e deletar marcas;
-Integração com crispy-forms para melhor formatação dos formulários;
-Rotas organizadas no brand/urls.py.